### PR TITLE
fix NoneType when doing normal GET requests

### DIFF
--- a/flask_apidoc/apidoc.py
+++ b/flask_apidoc/apidoc.py
@@ -100,7 +100,7 @@ class ApiDoc(object):
         api_project = self.__read_api_project()
 
         new_url = request.url_root.strip('/')
-        old_url = api_project.get('url')
+        old_url = api_project.get('url', new_url)
         data = data.replace(old_url, new_url)
 
         # creates a flask response to send


### PR DESCRIPTION
this is to fix a bug where the plugin dies at line 104 if the api project does not define a "url" field